### PR TITLE
Fix linked properties

### DIFF
--- a/src/components/MetadataTable/MetadataTable.js
+++ b/src/components/MetadataTable/MetadataTable.js
@@ -132,7 +132,17 @@ export function MetadataTable(props) {
     }
     //const newRow = { key: rowNumber.toString(), 'uuid': crypto.randomUUID() };
     const newRow = { key: rowNumber.toString(), 'uuid': crypto.randomUUID() };
-    currentTable.variableNames.forEach((name) => { newRow[name] = null; });
+    currentTable.variableNames.forEach((name) => {
+      if (currentTable.dependentVariables) {
+        if (name in currentTable.dependentVariables) {
+          newRow[name] = {'uuid': null, 'label': ''};
+        } else {
+          newRow[name] = null;
+        }
+      } else {
+        newRow[name] = null;
+      }
+    });
 
     return newRow;
   }
@@ -406,6 +416,15 @@ export function MetadataTable(props) {
       rowIndexList = selRows.map((rowKey) => rowKey - 1) // Key is 1-indexed, but array is 0-indexed.
     }  else {
       rowIndexList = [rowIndex]
+    }
+
+    oldValue = previousTableData[rowIndex][columnName];
+
+    if (typeof oldValue === 'object' && oldValue !== null && 'uuid' in oldValue) {
+      
+      console.log('old is object', oldValue)
+    } else {
+      console.log('old is not object', oldValue)
     }
 
     // Update the table data for the rows that should be updated

--- a/src/components/MetadataTable/TableComponents/EditableCell.js
+++ b/src/components/MetadataTable/TableComponents/EditableCell.js
@@ -54,6 +54,8 @@ export function EditableCell({
   // If mode is edit, it returns a form item with an input field, otherwise it returns the cell value
   //console.log(tables)
 
+  //console.log(columnName, '(value)', children)
+
   const form = useContext(EditableContext);
 
   const [isEditing, setIsEditing] = useState(false);

--- a/src/components/MetadataTable/TableComponents/EditableCell.js
+++ b/src/components/MetadataTable/TableComponents/EditableCell.js
@@ -107,6 +107,14 @@ export function EditableCell({
       const rowKey = rowRecord.key;
       const oldValue = rowRecord[columnName];
 
+      // This is a hack to make sure that the value is not an object 
+      // with a label and value property unless it is a dependent variable
+      if (newValue['value'] === newValue['label']) {
+        newValue = newValue['value'];
+      } else {
+        newValue = {'value': newValue['value'], 'label': newValue['label']};
+      }
+
       handleSave(rowKey, columnName, newValue, oldValue, 'dropdown')
     } catch (errInfo) {
       console.log('Save failed:', errInfo);
@@ -160,8 +168,8 @@ export function EditableCell({
 
     // Todo: Update this on table rerender.
     const dropdownOptions = getColumnDropdownOptions(columnName, filteredOptionMap, customOptionList)
-    const dropdownValue = children[1] || ''
-
+    //const dropdownValue = children[1] || '' // This did not work for cells with an object, i.e {value: '...', label: '...'}
+    const dropdownValue = rowRecord[columnName] || ''
     const selectStyle = {width: '100%', cursor: 'pointer'}
 
     childNode = isEditing ?
@@ -169,6 +177,7 @@ export function EditableCell({
         // Allow the user to add new options to a select if missing
         <FormItem name={columnName} title={columnTitle} isRequired={false}>
           <Select
+            labelInValue // This is needed to get both the value and label from the selected option on change
             showSearch
             options={dropdownOptions}
             optionFilterProp="label"
@@ -198,6 +207,7 @@ export function EditableCell({
         </FormItem>
       ) : (
         <Select
+          labelInValue // This is needed to get both the value and label from the selected option on change
           showSearch
           options={dropdownOptions}
           optionFilterProp="label"
@@ -357,14 +367,18 @@ function updateMetadataOptions(metadataOptionMap, tables, columnName) {
     const dependentVariableName = tables[currentTableName].dependentVariables[columnName][dependentTableName];
     if (tables[dependentTableName].data !== null) {
       let value = tables[dependentTableName].data.map((row) => row[dependentVariableName]);
+      let uuid = tables[dependentTableName].data.map((row) => row['uuid']);
+
       metadataOptionMap[columnName] = [
         {
           label: dependentTableName, 
-          options: value.map((name) => {
+          //use map with index to get the uuid
+          options: value.map((item, index) => {
+            // if name is an object, get the value property
             return {
-              value: name,
-              label: name,
-            };
+              value: uuid[index],
+              label: item,
+            }
           })
         }
       ];

--- a/src/helpers/table/getMetadataOptions.js
+++ b/src/helpers/table/getMetadataOptions.js
@@ -114,6 +114,8 @@ export function getMetadataOptions() {
     // Todo: Fix so that these are specific to the table a column is part of.
     // I.e both Subject and TissueSample has the IsPartOf column, but they should have different options
 
+    // Apparently not being used.
+
     // Loop through all specimen tables
     for (const key in specimenTables) {
       const dependentVariable = specimenTables[key].dependentVariables;
@@ -129,11 +131,17 @@ export function getMetadataOptions() {
               columnOptions[propName] = [
                 {
                   label: dependentVariableName, 
-                  options: value.map((name) => {
-                    return {
-                      value: name,
-                      label: name,
-                    };
+                  options: value.map((item) => {
+                    let optionsItem = {};
+
+                    if (typeof item === 'object' && item !== null) {
+                      optionsItem.value = item.value;
+                      optionsItem.label = item.label;
+                    } else {
+                      optionsItem.value = item;
+                      optionsItem.label = item;
+                    }
+                    return optionsItem;
                   })
                 }
               ];

--- a/src/metadata_new/schemaTables.js
+++ b/src/metadata_new/schemaTables.js
@@ -56,3 +56,37 @@ const tables = {
 
 
 export default tables
+
+
+
+// Alternative way to define dependent variables:
+
+// TissueSampleNew: {
+//   columnProps: tissueTableColumns,
+//   variableNames: tissueTableColumns.map((column) => column.key), // key or dataIndex?
+//   data: null,
+//   dependentVariables: [
+//     {
+//       'PropertyName': 'IsPartOf',
+//       'LinkedProperty': [
+//         {
+//           'TableName': 'TissueSampleCollection',
+//           'ColumnName': 'TissueSampleCollectionID'
+//         }
+//       ]
+//     }, 
+//     {
+//       'PropertyName': 'IsPartOf',
+//       'LinkedProperty': [
+//         {
+//           'TableName': 'TissueSample',
+//           'ColumnName': 'TissueSampleID'
+//         }, 
+//         {
+//           'TableName': 'Subject',
+//           'ColumnName': 'SubjectID'
+//         }
+//       ]
+//     },
+//   ]  
+// },


### PR DESCRIPTION
This PR fixes a few issues with the linked properties.
1) Values of linked properties were not correctly updated if undo/redo was used
2) Values of linked properties were not correctly updated if the linked item was removed
3) A linked property with an empty value appeared to be linked to an item with an empty ID.

